### PR TITLE
Add arguments to artisan commands

### DIFF
--- a/the-basics/connectors.md
+++ b/the-basics/connectors.md
@@ -5,7 +5,7 @@ Connectors are classes that register and store the requirements of a third-party
 ### Getting Started
 
 {% hint style="info" %}
-If you are using Laravel, you can use the **php artisan saloon:connector** Artisan command to create a connector.
+If you are using Laravel, you can use the **php artisan saloon:connector YourCustomIntegrationName YourCustomConnectorName** Artisan command to create a connector.
 {% endhint %}
 
 Firstly create a class in your application and extend the base **SaloonConnector** abstract class. Then extend the **defineBaseUrl** public function and define the base URL of the API. You do not have to worry about trailing slashes as Saloon will clean these up for you.

--- a/the-basics/requests/README.md
+++ b/the-basics/requests/README.md
@@ -3,7 +3,7 @@
 Saloon Requests are reusable classes that define each request of the API you want to make. They contain the request's method, as well as any default headers, or data that should be used.
 
 {% hint style="info" %}
-If you are using Laravel, you can use the **php artisan saloon:request** Artisan command to create a request.
+If you are using Laravel, you can use the **php artisan saloon:request YourCustomIntegrationName YourCustomRequestName** Artisan command to create a request.
 {% endhint %}
 
 ### Example Request


### PR DESCRIPTION
I updated a couple of the artisan command examples that need arguments to create a connector and request. It would be nice to have a doc page for the Laravel package with details of the commands available as well, but maybe this would be a good start.