### PR TITLE
Update `authentication.md` with the correct method type

### DIFF
--- a/next-steps/authentication.md
+++ b/next-steps/authentication.md
@@ -83,7 +83,7 @@ class GetForgeServerRequest extends SaloonRequest
 {
     // ...
     
-    protected function defaultAuth(): ?AuthenticatorInterface
+    public function defaultAuth(): ?AuthenticatorInterface
     {
         return new BasicAuthenticator('username', 'password');
     }


### PR DESCRIPTION
The method `defaultAuth` uses a protected method in the docs, but in the source code the method is [public](https://github.com/Sammyjo20/Saloon/blob/v1/src/Traits/AuthenticatesRequests.php#L24).