### PR TITLE
Typo on HasFormBody

### DIFF
--- a/upgrade/upgrading-from-v1.md
+++ b/upgrade/upgrading-from-v1.md
@@ -268,7 +268,7 @@ Saloon has also rebuilt the way that request data/body is sent using POST/PUT/PA
 **HasFormParams**
 
 * Find: `use Saloon\Traits\Plugins\HasFormParams`
-* Replace: `use Saloon\Traits\Body\HasJsonBody`
+* Replace: `use Saloon\Traits\Body\HasFormBody`
 
 **HasMultipartBody**
 


### PR DESCRIPTION
Corrected the find/replace for `HasFormParams` -> `HasFormBody`