### PR TITLE
Correction to nullable string for Response Class

### DIFF
--- a/the-basics/responses.md
+++ b/the-basics/responses.md
@@ -95,7 +95,7 @@ class Forge extends Connector
 {
     // {...}
     
-<strong>    protected string $response = CustomResponse::class;
+<strong>    protected ?string $response = CustomResponse::class;
 </strong>}
 </code></pre>
 {% endtab %}
@@ -109,7 +109,7 @@ class GetServersRequest extends Request
 {
     // {...}
     
-<strong>    protected string $response = CustomResponse::class;
+<strong>    protected ?string $response = CustomResponse::class;
 </strong>}
 </code></pre>
 {% endtab %}


### PR DESCRIPTION
When going with the original v2 documents, I got the following error:

`Type of ReedTech\AzureServiceBus\Requests\SendMessage::$response must be ?string (as in class Saloon\Http\Request`

Changing my code to match what I updated the docs to reflect fixes my issue.

I assume the docs were just a bit out of date? If so, hope this helps! Thanks!