### PR TITLE
Use correct imports and fix syntax errors on faking page

### DIFF
--- a/digging-deepeer/faking-mock-responses/manual-fake-responses.md
+++ b/digging-deepeer/faking-mock-responses/manual-fake-responses.md
@@ -212,7 +212,10 @@ The **AssertSent / AssertNotSent** are the two most powerful expectation methods
 ```php
 <?php
 
-// ... 
+use Saloon\Contracts\Request;
+use Saloon\Contracts\Response;
+
+// ...
 
 $forge = new ForgeConnector;
 $forge->withMockClient($mockClient);
@@ -223,9 +226,9 @@ $mockClient->assertSent(GetForgeServerRequest::class);
 
 $mockClient->assertSent('/servers/*');
 
-$mockClient->assertSent(function (SaloonRequest $request, SaloonResponse $response) {
-    return $request instanceof GetForgeServerRequest::class 
-    && $request->serverId === 123456;
+$mockClient->assertSent(function (Request $request, Response $response) {
+    return $request instanceof GetForgeServerRequest
+        && $request->serverId === 123456;
 });
 ```
 
@@ -239,7 +242,7 @@ Your test may require you to mock your own exceptions that might get thrown. To 
 $mockClient = new MockClient([
     MockResponse::make(['name' => 'Sam'], 200)->throw(new MyException('Something bad!'))
 ]);
- 
+
 // ...
 ```
 
@@ -250,12 +253,12 @@ Sometimes, you may need to return a custom mock response based on the request th
 ```php
 <?php
 
-use Saloon\Contracts\Request;
+use Saloon\Contracts\PendingRequest;
 
 $mockClient = new MockClient([
     function (PendingRequest $request): MockResponse {
         // Write some custom logic here...
-    
+
         return new MockResponse([...]);
     },
 ]);


### PR DESCRIPTION
Congrats on the v2 release! 

While migrating, I found a few small errors in the documentation on faking responses.

- The `assertSent` function still accepted `SaloonRequest` and `SaloonResponse` classes. I changed this to the `Request` and `Response` contract classes, respectively. I also added the respective imports to help make it less ambiguous.
- `instanceof` checks just use the class' name, without `::class`. That would produce a syntax error.
  - I adjusted the indentation of the `&&` block, too. That's maybe more personal style, but I found it pretty hard to read the way it was.
- The section on passing a closure to the `MockClient` used the wrong import for `PendingRequest` 
- My editor also removed trailing spaces in a few places 😅 