### PR TITLE
Wrong method name used in Docs

### DIFF
--- a/the-basics/headers.md
+++ b/the-basics/headers.md
@@ -69,7 +69,7 @@ class GetServersRequest extends Request
     
     protected string $username;
     
-    public function __constructor(string $username)
+    public function __construct(string $username)
     {
         $this->username = $username;
     }


### PR DESCRIPTION
The method name should be __construct and not __constructor