### PR TITLE
Update laravel job middleware name

### DIFF
--- a/digging-deeper/handling-rate-limits.md
+++ b/digging-deeper/handling-rate-limits.md
@@ -374,7 +374,7 @@ use Saloon\RateLimitPlugin\Helpers\ApiRateLimited;
  
 public function middleware(): array
 {
-    return [new ApiRateLimited];
+    return [new LaravelRateLimitMiddleware];
 }
 ```
 


### PR DESCRIPTION
Thanks a lot for your package.

I just realized when using the rate limit api there is no `ApiRateLimited` middleware but a  `LaravelRateLimitMiddleware` so I assume this was renamed after updating the docs.