### PR TITLE
Update HasJsonBody example

### DIFF
--- a/the-basics/request-body-data/json-body.md
+++ b/the-basics/request-body-data/json-body.md
@@ -85,12 +85,12 @@ class CreateServerRequest extends Request implements HasBody
     protected Method $method = Method::POST;
     
     public function __construct(
-        protected array $body
+        protected array $payload
     ){}
     
     protected function defaultBody(): array
     {
-        return $this->body;
+        return $this->payload;
     }
 }
 ```


### PR DESCRIPTION
When using `$body` argument, got an error:

`App\Http\Integrations\Example\Requests\ExampleRequest and Saloon\Traits\Body\HasJsonBody define the same property ($body) in the composition of App\Http\Integrations\Example\Requests\ExampleRequest. However, the definition differs and is considered incompatible. Class was composed`

When I renamed argument to `$payload` it works.