### PR TITLE
add documentation for list command

### DIFF
--- a/plugins/laravel-integration.md
+++ b/plugins/laravel-integration.md
@@ -46,7 +46,8 @@ Each of the commands will create files within the `App\Http\Integrations` namesp
 | saloon:auth \<Integration Name> \<Authenticator Name>        | Creates a custom authenticator |
 | saloon:oauth-connector \<Integration Name> \<Connector Name> | Creates a new OAuth2 connector |
 
-You can use the `saloon:list` command to display information about Saloon usage within your application.
+You can use the `saloon:list` command to display information about Saloon usage within your application such
+as your integrations and what requests, connectors, plugins, responses an authenticators they have.
 
 ### Laravel HTTP Client Sender
 

--- a/plugins/laravel-integration.md
+++ b/plugins/laravel-integration.md
@@ -46,6 +46,8 @@ Each of the commands will create files within the `App\Http\Integrations` namesp
 | saloon:auth \<Integration Name> \<Authenticator Name>        | Creates a custom authenticator |
 | saloon:oauth-connector \<Integration Name> \<Connector Name> | Creates a new OAuth2 connector |
 
+You can use the `saloon:list` command to display information about Saloon usage within your application.
+
 ### Laravel HTTP Client Sender
 
 Saloon comes with a sender built just for Laravel. The HTTP sender uses Laravel's [HTTP client](https://laravel.com/docs/9.x/http-client#main-content) under the hood, which allows your requests to be handled by Laravel just like using the HTTP client directly. This means Saloon's requests can be recorded in Telescope and also picked up by Laravel's event system.

--- a/plugins/laravel-integration.md
+++ b/plugins/laravel-integration.md
@@ -46,8 +46,8 @@ Each of the commands will create files within the `App\Http\Integrations` namesp
 | saloon:auth \<Integration Name> \<Authenticator Name>        | Creates a custom authenticator |
 | saloon:oauth-connector \<Integration Name> \<Connector Name> | Creates a new OAuth2 connector |
 
-You can use the `saloon:list` command to display information about Saloon usage within your application such
-as your integrations and what requests, connectors, plugins, responses an authenticators they have.
+You can use the `saloon:list` command to get information about Saloon usage within your application. This 
+includes details about your integrations, as well as associated requests, connectors, plugins, responses, and authenticators.
 
 ### Laravel HTTP Client Sender
 


### PR DESCRIPTION
Adds some brief documentation for the newly added `saloon:list` command into the laravel plugin.