### PR TITLE
Update OAuth2 code examples

### DIFF
--- a/digging-deeper/oauth2-authentication/client-credentials-grant.md
+++ b/digging-deeper/oauth2-authentication/client-credentials-grant.md
@@ -215,7 +215,7 @@ $connector->getAccessToken(requestModifier: function (Request $request) {
 ```
 {% endtab %}
 
-{% tab title="Untitled" %}
+{% tab title="All Requests" %}
 <pre class="language-php"><code class="lang-php">&#x3C;?php
 
 use Saloon\Http\Request;

--- a/digging-deeper/oauth2-authentication/client-credentials-grant.md
+++ b/digging-deeper/oauth2-authentication/client-credentials-grant.md
@@ -64,7 +64,7 @@ class WarehouseConnector extends Connector
         return OAuthConfig::make()
             ->setClientId('my-client-id')
             ->setClientSecret('my-client-secret')
-	    ->setDefaultScopes(['inventory.read'])
+            ->setDefaultScopes(['inventory.read'])
             ->setTokenEndpoint('/oauth/token')
             ->setRequestModifier(function (Request $request) {
                 // Optional: Modify the requests being sent.
@@ -226,8 +226,8 @@ protected function defaultOauthConfig(): OAuthConfig
     return OAuthConfig::make()
         ->setClientId('my-client-id')
         ->setClientSecret('my-client-secret')
-<strong>	->setRequestModifier(function (GetClientCredentialsTokenRequest $request) {
-</strong><strong>	     //
+<strong>        ->setRequestModifier(function (GetClientCredentialsTokenRequest $request) {
+</strong><strong>            //
 </strong><strong>        )},
 </strong>}
 </code></pre>

--- a/digging-deeper/oauth2-authentication/client-credentials-grant.md
+++ b/digging-deeper/oauth2-authentication/client-credentials-grant.md
@@ -53,12 +53,12 @@ use Saloon\Traits\OAuth2\ClientCredentialsGrant;
 class WarehouseConnector extends Connector
 {
     use ClientCredentialsGrant;
-    
+
     public function resolveBaseUrl(): string
     {
         return 'https://local-warehouse.app';
     }
-    
+
     protected function defaultOauthConfig(): OAuthConfig
     {
         return OAuthConfig::make()
@@ -92,13 +92,13 @@ use Saloon\Traits\OAuth2\ClientCredentialsGrant;
 class WarehouseConnector extends Connector
 {
     use ClientCredentialsGrant;
-    
+
     public function __construct(string $clientId, string $clientSecret)
     {
         $this->oauthConfig()->setClientId($clientId);
         $this->oauthConfig()->setClientSecret($clientSecret);
     }
-    
+
     // ...
 }
 ```

--- a/digging-deeper/oauth2-authentication/oauth2-authentication.md
+++ b/digging-deeper/oauth2-authentication/oauth2-authentication.md
@@ -69,7 +69,7 @@ class SpotifyConnector extends Connector
     public function resolveBaseUrl(): string
     {
         // Spotify's API has a different base URL for OAuth2 auth.
-    
+
         return 'https://api.spotify.com/v1';
     }
 
@@ -108,13 +108,13 @@ use Saloon\Traits\OAuth2\AuthorizationCodeGrant;
 class SpotifyConnector extends Connector
 {
     use AuthorizationCodeGrant;
-    
+
 <strong>    public function __construct(string $clientId, string $clientSecret)
 </strong>    {
         $this->oauthConfig()->setClientId($clientId);
         $this->oauthConfig()->setClientSecret($clientSecret);
     }
-    
+
     // ...
 }
 </code></pre>
@@ -218,7 +218,7 @@ $authenticator = $connector->getAccessToken($code);
 
 // Securely store this against your user.
 
-$serialized = $authenticator->serialize(); 
+$serialized = $authenticator->serialize();
 
 // Unserialize the authenticator when retrieving it
 
@@ -258,7 +258,7 @@ if ($authenticator->hasExpired()) {
     // We'll refresh the access token which will return a new authenticator
     // which we can store against our user in our application.
 
-    $authenticator = $connector->refreshAccessToken($authenticator);    
+    $authenticator = $connector->refreshAccessToken($authenticator);
     $user->updateAuthenticator($authenticator);
 }
 
@@ -380,12 +380,12 @@ class SpotifyConnector extends Connector
     {
         return new CustomGetAccessTokenRequest($code, $oauthConfig);
     }
-    
+
     protected function resolveRefreshTokenRequest(OAuthConfig $oauthConfig, string $refreshToken): Request
     {
         return new CustomGetRefreshTokenRequest($oauthConfig, $refreshToken);
     }
-    
+
     protected function resolveUserRequest(OAuthConfig $oauthConfig): Request
     {
         return new CustomGetUserRequest($oauthConfig);

--- a/digging-deeper/oauth2-authentication/oauth2-authentication.md
+++ b/digging-deeper/oauth2-authentication/oauth2-authentication.md
@@ -78,9 +78,9 @@ class SpotifyConnector extends Connector
         return OAuthConfig::make()
             ->setClientId('my-client-id')
             ->setClientSecret('my-client-secret')
-	    ->setDefaultScopes(['user-read-currently-playing'])
+            ->setDefaultScopes(['user-read-currently-playing'])
             ->setRedirectUri('https://my-app.saloon.dev/auth/callback')
-	    ->setAuthorizeEndpoint('https://accounts.spotify.com/authorize')
+            ->setAuthorizeEndpoint('https://accounts.spotify.com/authorize')
             ->setTokenEndpoint('https://accounts.spotify.com/api/token')
             ->setUserEndpoint('/me')
             ->setRequestModifier(function (Request $request) {
@@ -343,11 +343,11 @@ protected function defaultOauthConfig(): OAuthConfig
         ->setClientId('my-client-id')
         ->setClientSecret('my-client-secret')
         ->setRedirectUri('https://my-app.saloon.dev/auth/callback')
-	->setRequestModifier(function (Request $request) {
-	     // This callback is invoked on every request, so you 
-	     // may want to use if-statements or a match statement
-	     // to apply conditions based on request.
-	
+        ->setRequestModifier(function (Request $request) {
+             // This callback is invoked on every request, so you
+             // may want to use if-statements or a match statement
+             // to apply conditions based on request.
+
              if ($request instanceof GetAccessTokenRequest) {
                  $request->query()->add('access_type', 'offline');
              }

--- a/digging-deeper/oauth2-authentication/oauth2-authentication.md
+++ b/digging-deeper/oauth2-authentication/oauth2-authentication.md
@@ -344,21 +344,21 @@ protected function defaultOauthConfig(): OAuthConfig
         ->setClientSecret('my-client-secret')
         ->setRedirectUri('https://my-app.saloon.dev/auth/callback')
         ->setRequestModifier(function (Request $request) {
-             // This callback is invoked on every request, so you
-             // may want to use if-statements or a match statement
-             // to apply conditions based on request.
+            // This callback is invoked on every request, so you
+            // may want to use if-statements or a match statement
+            // to apply conditions based on request.
 
-             if ($request instanceof GetAccessTokenRequest) {
-                 $request->query()->add('access_type', 'offline');
-             }
-             
-             if ($request instanceof GetRefreshTokenRequest) {
-                 $request->headers()->add('X-App-Key', $appKey);
-             }
-             
-             if ($request instanceof GetUserRequest) {
-                 $request->headers('Accept', 'text/plain');
-             }
+            if ($request instanceof GetAccessTokenRequest) {
+                $request->query()->add('access_type', 'offline');
+            }
+
+            if ($request instanceof GetRefreshTokenRequest) {
+                $request->headers()->add('X-App-Key', $appKey);
+            }
+
+            if ($request instanceof GetUserRequest) {
+                $request->headers('Accept', 'text/plain');
+            }
         }),
 }
 ```


### PR DESCRIPTION
Howdy!

Noticed that some of the OAuth2 code examples have odd indentation thanks to a mix of tabs and spaces.

![Screen Shot 2024-06-21 at 00 54 09](https://github.com/Sammyjo20/saloon-docs/assets/949285/d6632c5c-267a-4d9c-91a5-1f808f74f9b3)

While I was in there, also did some other minor clean up:-

* Making indentation consistent (multiples of four spaces)
* Removing some trailing whitespace
* Renaming one of the tabs