### PR TITLE
Fix authenticator getExpiresAt method name in docs

### DIFF
--- a/digging-deeper/oauth2-authentication/oauth2-authentication.md
+++ b/digging-deeper/oauth2-authentication/oauth2-authentication.md
@@ -234,7 +234,7 @@ The authenticator returned by Saloon when using the `getAccessToken` or `refresh
 
 $authenticator->getAccessToken();
 $authenticator->getRefreshToken();
-$authenticator->getExpiry();
+$authenticator->getExpiresAt();
 
 $authenticator->hasExpired();
 $authenticator->hasNotExpired();


### PR DESCRIPTION
In the OAuth2 authentication docs, fixed the reference to `$authenticator->getExpiresAt()` function.