### PR TITLE
Replace HasBody with HasStreamBody in documentation

### DIFF
--- a/the-basics/request-body-data/stream-body.md
+++ b/the-basics/request-body-data/stream-body.md
@@ -15,7 +15,7 @@ use Saloon\Contracts\Body\HasBody;
 }
 </code></pre>
 
-Next, you will need to add the `HasBody` trait to your request. This trait will implement the `body()` method that the `HasBody` interface requires. It also provides a method `defaultBody()` which you can extend to provide a default body on your request.
+Next, you will need to add the `HasStreamBody` trait to your request. This trait will implement the `body()` method that the `HasBody` interface requires. It also provides a method `defaultBody()` which you can extend to provide a default body on your request.
 
 <pre class="language-php"><code class="lang-php">&#x3C;?php
 


### PR DESCRIPTION
The current documentation has a minor error that may be confusing to new users of Saloon.